### PR TITLE
Disable 2018 builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 //Leave the above line alone.  It identifies this as a groovy script.
-@Library('vs-build-tools') _Disable 2018 builds
-dev/disable_2018_builds
+@Library('vs-build-tools') _
 
 def lvVersions = ['2019', '2020']
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,9 @@
 #!/usr/bin/env groovy
 //Leave the above line alone.  It identifies this as a groovy script.
-@Library('vs-build-tools') _
+@Library('vs-build-tools') _Disable 2018 builds
+dev/disable_2018_builds
 
-def lvVersions = ['2018', '2019', '2020']
+def lvVersions = ['2019', '2020']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)
 diffPipeline(lvVersions[0])


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-classes/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Disable 2018 builds of the repo

### Why should this Pull Request be merged?

Preparing for future releases, we are removing 2018 from the build nodes.
Without removing 2018 support from the Jenkinsfile, future builds of main will fail.

### What testing has been done?

None